### PR TITLE
np.bool -> bool

### DIFF
--- a/crafter/worldgen.py
+++ b/crafter/worldgen.py
@@ -9,7 +9,7 @@ from . import objects
 
 def generate_world(world, player):
   simplex = opensimplex.OpenSimplex(seed=world.random.randint(0, 2 ** 31 - 1))
-  tunnels = np.zeros(world.area, np.bool)
+  tunnels = np.zeros(world.area, bool)
   for x in range(world.area[0]):
     for y in range(world.area[1]):
       _set_material(world, (x, y), player, tunnels, simplex)


### PR DESCRIPTION
To get rid of the following warning

DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations