### PR TITLE
import imageio -> import imageio.v2 as imageio

### DIFF
--- a/crafter/engine.py
+++ b/crafter/engine.py
@@ -2,7 +2,7 @@ import collections
 import functools
 import pathlib
 
-import imageio
+import imageio.v2 as imageio
 import numpy as np
 from PIL import Image, ImageEnhance
 

--- a/crafter/worldgen.py
+++ b/crafter/worldgen.py
@@ -9,7 +9,7 @@ from . import objects
 
 def generate_world(world, player):
   simplex = opensimplex.OpenSimplex(seed=world.random.randint(0, 2 ** 31 - 1))
-  tunnels = np.zeros(world.area, np.bool)
+  tunnels = np.zeros(world.area, bool)
   for x in range(world.area[0]):
     for y in range(world.area[1]):
       _set_material(world, (x, y), player, tunnels, simplex)

--- a/crafter/worldgen.py
+++ b/crafter/worldgen.py
@@ -9,7 +9,7 @@ from . import objects
 
 def generate_world(world, player):
   simplex = opensimplex.OpenSimplex(seed=world.random.randint(0, 2 ** 31 - 1))
-  tunnels = np.zeros(world.area, bool)
+  tunnels = np.zeros(world.area, np.bool)
   for x in range(world.area[0]):
     for y in range(world.area[1]):
       _set_material(world, (x, y), player, tunnels, simplex)


### PR DESCRIPTION
DeprecationWarning: Starting with ImageIO v3 the behavior of this function will switch to that of iio.v3.imread. To keep the current behavior (and make this warning disappear) use `import imageio.v2 as imageio` or call `imageio.v2.imread` directly.