### PR TITLE
Use new YAML API (for ruamel.yaml >= 0.18)

### DIFF
--- a/crafter/constants.py
+++ b/crafter/constants.py
@@ -3,5 +3,6 @@ import pathlib
 import ruamel.yaml as yaml
 
 root = pathlib.Path(__file__).parent
-for key, value in yaml.safe_load((root / 'data.yaml').read_text()).items():
+yaml = yaml.YAML(typ='safe', pure=True)
+for key, value in yaml.load((root / 'data.yaml').read_text()).items():
   globals()[key] = value

--- a/crafter/constants.py
+++ b/crafter/constants.py
@@ -1,8 +1,8 @@
 import pathlib
 
-import ruamel.yaml as yaml
+import ruamel.yaml
 
 root = pathlib.Path(__file__).parent
-yaml = yaml.YAML(typ='safe', pure=True)
+yaml = ruamel.yaml.YAML(typ='safe', pure=True)
 for key, value in yaml.load((root / 'data.yaml').read_text()).items():
   globals()[key] = value


### PR DESCRIPTION
The old `.load()` API has been removed in v0.18, as outlined in the [changelog](https://pypi.org/project/ruamel.yaml/).

Closes #20 
Avoids restricting the ruamel yaml version (unlike #21)